### PR TITLE
BUG/MEDIUM: AutoTable: handle stringified functions from JSON configs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@zenetys/ztable",
-    "version": "2.1.12",
+    "version": "2.1.13",
     "author": "Zlab team, ZENETYS",
     "email": "zlab@zenetys.com",
     "url": "https://tools.zenetys.com/ztable/",


### PR DESCRIPTION
Previously, when loading a custom configuration for the AutoTable, you could implement custom methods and functions to format your data, as long as the config was in Javascript. But we offer the possibility to fetch a remote config from a URL, which retrieves a JSON config, so functions are in string format and need to be handled and converted. This commit aims to detect when a config property starts with { in order to turn it into a JS function.